### PR TITLE
keytar4 add credential options - to support different credential persistance and type

### DIFF
--- a/lib/keytar.js
+++ b/lib/keytar.js
@@ -30,7 +30,7 @@ module.exports = {
     return callbackPromise(callback => keytar.getPassword(service, account, callback))
   },
 
-  setPassword: function (service, account, password, targetname = null, credType = -1, credPersist = -1) {
+  setPassword: function (service, account, password, targetname = '', credType = -1, credPersist = -1) {
     checkRequired(service, 'Service')
     checkRequired(account, 'Account')
     checkRequired(password, 'Password')

--- a/lib/keytar.js
+++ b/lib/keytar.js
@@ -30,12 +30,12 @@ module.exports = {
     return callbackPromise(callback => keytar.getPassword(service, account, callback))
   },
 
-  setPassword: function (service, account, password) {
+  setPassword: function (service, account, password, targetname = null, credType = -1, credPersist = -1) {
     checkRequired(service, 'Service')
     checkRequired(account, 'Account')
     checkRequired(password, 'Password')
 
-    return callbackPromise(callback => keytar.setPassword(service, account, password, callback))
+    return callbackPromise(callback => keytar.setPassword(service, account, password, targetname, credType, credPersist, callback))
   },
 
   deletePassword: function (service, account) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "main": "./lib/keytar.js",
   "name": "keytar4",
   "description": "Bindings to native Mac/Linux/Windows password APIs",
-  "version": "4.0.5",
+  "version": "4.1.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "main": "./lib/keytar.js",
   "name": "keytar4",
   "description": "Bindings to native Mac/Linux/Windows password APIs",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/async.cc
+++ b/src/async.cc
@@ -26,13 +26,21 @@ SetPasswordWorker::~SetPasswordWorker() {}
 
 void SetPasswordWorker::Execute() {
   std::string error;
-  KEYTAR_OP_RESULT result = keytar::SetPassword(service,
-                                                account,
-                                                password,
-                                                targetname,
-                                                credType,
-                                                credPersist,
-                                                &error);
+  KEYTAR_OP_RESULT result;
+  #ifdef _WIN32
+  result = keytar::SetPassword(service,
+                               account,
+                               password,
+                               targetname,
+                               credType,
+                               credPersist,
+                               &error);
+  #else
+    result = keytar::SetPassword(service,
+                                account,
+                                password,
+                                &error);
+  #endif
   if (result == keytar::FAIL_ERROR) {
     SetErrorMessage(error.c_str());
   }

--- a/src/async.cc
+++ b/src/async.cc
@@ -10,11 +10,17 @@ SetPasswordWorker::SetPasswordWorker(
   const std::string& service,
   const std::string& account,
   const std::string& password,
+  const std::string& targetname,
+  const int credType,
+  const int credPersist,
   Nan::Callback* callback
 ) : AsyncWorker(callback),
     service(service),
     account(account),
-    password(password) {}
+    password(password),
+    targetname(targetname), 
+    credType(credType),
+    credPersist(credPersist) {}
 
 SetPasswordWorker::~SetPasswordWorker() {}
 
@@ -23,6 +29,9 @@ void SetPasswordWorker::Execute() {
   KEYTAR_OP_RESULT result = keytar::SetPassword(service,
                                                 account,
                                                 password,
+                                                targetname,
+                                                credType,
+                                                credPersist,
                                                 &error);
   if (result == keytar::FAIL_ERROR) {
     SetErrorMessage(error.c_str());

--- a/src/async.h
+++ b/src/async.h
@@ -6,7 +6,8 @@
 
 class SetPasswordWorker : public Nan::AsyncWorker {
   public:
-    SetPasswordWorker(const std::string& service, const std::string& account, const std::string& password,
+    SetPasswordWorker(const std::string& service, const std::string& account, const std::string& password, const std::string& targetname,
+                       const int credType, const int credPersist,
                       Nan::Callback* callback);
 
     ~SetPasswordWorker();
@@ -17,6 +18,9 @@ class SetPasswordWorker : public Nan::AsyncWorker {
     const std::string service;
     const std::string account;
     const std::string password;
+    const std::string targetname;
+    const int credType;
+    const int credPersist;
 };
 
 class GetPasswordWorker : public Nan::AsyncWorker {

--- a/src/keytar.h
+++ b/src/keytar.h
@@ -11,6 +11,7 @@ enum KEYTAR_OP_RESULT {
   FAIL_NONFATAL
 };
 
+#ifdef _WIN32
 KEYTAR_OP_RESULT SetPassword(const std::string& service,
                              const std::string& account,
                              const std::string& password,
@@ -18,6 +19,12 @@ KEYTAR_OP_RESULT SetPassword(const std::string& service,
                              const int credType,
                              const int credPersist,
                              std::string* error);
+#else
+KEYTAR_OP_RESULT SetPassword(const std::string& service,
+                             const std::string& account,
+                             const std::string& password,
+                             std::string* error);
+#endif
 
 KEYTAR_OP_RESULT GetPassword(const std::string& service,
                              const std::string& account,

--- a/src/keytar.h
+++ b/src/keytar.h
@@ -14,6 +14,9 @@ enum KEYTAR_OP_RESULT {
 KEYTAR_OP_RESULT SetPassword(const std::string& service,
                              const std::string& account,
                              const std::string& password,
+                             const std::string& targetname,
+                             const int credType,
+                             const int credPersist,
                              std::string* error);
 
 KEYTAR_OP_RESULT GetPassword(const std::string& service,

--- a/src/keytar_win.cc
+++ b/src/keytar_win.cc
@@ -71,20 +71,12 @@ KEYTAR_OP_RESULT SetPassword(const std::string& service,
     }
   }
   CREDENTIALW cred = { 0 };
-  // cred.Type = CRED_TYPE_GENERIC;
-  // cred.Type = CRED_TYPE_DOMAIN_PASSWORD;
   cred.Type = static_cast<DWORD>(credType);
-  // cred.TargetName = const_cast<char*>(target_name.c_str());
   cred.TargetName = utf8ToWideChar(target_name);
-  // cred.UserName = const_cast<char*>(account.c_str());
   cred.UserName = utf8ToWideChar(account);
-  // cred.CredentialBlobSize = password.size();
-  // cred.CredentialBlobSize = static_cast<DWORD>((password.size()) + 1) * sizeof(WCHAR);
-
   LPWSTR temp = utf8ToWideChar(password);
   cred.CredentialBlobSize = static_cast<DWORD>(wcslen(temp) * sizeof(WCHAR));
   cred.CredentialBlob = (LPBYTE)(temp);
-  // cred.Persist = CRED_PERSIST_LOCAL_MACHINE;
   cred.Persist = static_cast<DWORD>(credPersist);
 
   bool result = ::CredWriteW(&cred, 0);

--- a/src/keytar_win.cc
+++ b/src/keytar_win.cc
@@ -6,6 +6,30 @@
 
 namespace keytar {
 
+LPWSTR utf8ToWideChar(std::string utf8) {
+  int wide_char_length = MultiByteToWideChar(CP_UTF8,
+                                             0,
+                                             utf8.c_str(),
+                                             -1,
+                                             NULL,
+                                             0);
+  if (wide_char_length == 0) {
+    return NULL;
+  }
+
+  LPWSTR result = new WCHAR[wide_char_length];
+  if (MultiByteToWideChar(CP_UTF8,
+                          0,
+                          utf8.c_str(),
+                          -1,
+                          result,
+                          wide_char_length) == 0) {
+    delete[] result;
+    return NULL;
+  }
+
+  return result;
+}
 std::string getErrorMessage(DWORD errorCode) {
   LPVOID errBuffer;
   ::FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
@@ -18,19 +42,52 @@ std::string getErrorMessage(DWORD errorCode) {
 KEYTAR_OP_RESULT SetPassword(const std::string& service,
                  const std::string& account,
                  const std::string& password,
+                 const std::string& targetname,
+                 const int credType,
+                 const int credPersist,
                  std::string* errStr) {
   std::string target_name = service + '/' + account;
+  if (targetname.empty()) {
+    target_name = service + '/' + account;
+  } else {
+    target_name = targetname;
+  }
   static std::mutex mutex;
   std::lock_guard<std::mutex> lock(mutex);
+  if (targetname.empty()) {
+    CREDENTIAL cred = { 0 };
+    cred.Type = CRED_TYPE_GENERIC;
+    cred.TargetName = const_cast<char*>(target_name.c_str());
+    cred.CredentialBlobSize = password.size();
+    cred.CredentialBlob = (LPBYTE)(password.data());
+    cred.Persist = CRED_PERSIST_LOCAL_MACHINE;
 
-  CREDENTIAL cred = { 0 };
-  cred.Type = CRED_TYPE_GENERIC;
-  cred.TargetName = const_cast<char*>(target_name.c_str());
-  cred.CredentialBlobSize = password.size();
-  cred.CredentialBlob = (LPBYTE)(password.data());
-  cred.Persist = CRED_PERSIST_LOCAL_MACHINE;
+    bool result = ::CredWrite(&cred, 0);
+    if (!result) {
+      *errStr = getErrorMessage(::GetLastError());
+      return FAIL_ERROR;
+    } else {
+      return SUCCESS;
+    }
+  }
+  CREDENTIALW cred = { 0 };
+  // cred.Type = CRED_TYPE_GENERIC;
+  // cred.Type = CRED_TYPE_DOMAIN_PASSWORD;
+  cred.Type = static_cast<DWORD>(credType);
+  // cred.TargetName = const_cast<char*>(target_name.c_str());
+  cred.TargetName = utf8ToWideChar(target_name);
+  // cred.UserName = const_cast<char*>(account.c_str());
+  cred.UserName = utf8ToWideChar(account);
+  // cred.CredentialBlobSize = password.size();
+  // cred.CredentialBlobSize = static_cast<DWORD>((password.size()) + 1) * sizeof(WCHAR);
 
-  bool result = ::CredWrite(&cred, 0);
+  LPWSTR temp = utf8ToWideChar(password);
+  cred.CredentialBlobSize = static_cast<DWORD>(wcslen(temp) * sizeof(WCHAR));
+  cred.CredentialBlob = (LPBYTE)(temp);
+  // cred.Persist = CRED_PERSIST_LOCAL_MACHINE;
+  cred.Persist = static_cast<DWORD>(credPersist);
+
+  bool result = ::CredWriteW(&cred, 0);
   if (!result) {
     *errStr = getErrorMessage(::GetLastError());
     return FAIL_ERROR;

--- a/src/main.cc
+++ b/src/main.cc
@@ -8,7 +8,10 @@ NAN_METHOD(SetPassword) {
     *v8::String::Utf8Value(info[0]),
     *v8::String::Utf8Value(info[1]),
     *v8::String::Utf8Value(info[2]),
-    new Nan::Callback(info[3].As<v8::Function>()));
+    *v8::String::Utf8Value(info[3]),
+    info[4]->Int32Value(),
+    info[5]->Int32Value(),
+    new Nan::Callback(info[6].As<v8::Function>()));
   Nan::AsyncQueueWorker(worker);
 }
 


### PR DESCRIPTION
These changes are made behind an ifdef for only the Windows version of Keytar.

1. Pass in a targetname -> **This is used as a flag so that the old code is still run when targetname is not passed.**
2. Added property for credential type that can be optionally passed along with target name
3. Added property for credential persistance that can be optionally passed along with target name

Also, moved the API from CredWrite which in turn was calling credWriteA to credWriteW. 
Calling credWriteA causes sizing inconsistencies that would fail some credential writes to the Windows Type. 

The UTF8ToWChar function has been taken from the keytar master branch.

Here is the MSDN for credential options: https://msdn.microsoft.com/en-us/library/windows/desktop/aa374788(v=vs.85).aspx 